### PR TITLE
Implement remind feature for tasks due within a specified number of days

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: GUI.Launcher
+

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 application {
-    mainClass.set("Launcher")
+    mainClass.set("GUI.Launcher")
 }
 
 dependencies {
@@ -29,6 +29,10 @@ dependencies {
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
+}
+
+shadowJar {
+    archiveFileName = 'Diego.jar'
 }
 
 

--- a/data/Diego.txt
+++ b/data/Diego.txt
@@ -1,3 +1,5 @@
-E | 1 | project meeting | Mon 2pm | 4pm
 T | 1 | eat
 T | 0 | sleep
+D | 0 | return book | 2019-12-02 1800
+D | 0 | return book | 2024-09-06 1800
+D | 0 | return book | 2024-09-05

--- a/src/main/java/Commands/ReminderCommand.java
+++ b/src/main/java/Commands/ReminderCommand.java
@@ -1,0 +1,36 @@
+package Commands;
+
+import Main.Storage;
+import Main.Ui;
+import Tasks.TaskList;
+import Tasks.Task;
+
+/**
+ * Represents a command to show reminders for tasks that are due within a specified number of days.
+ */
+public class ReminderCommand implements Command {
+
+    private int days;
+
+    /**
+     * Constructs a new ReminderCommand with the specified number of days.
+     *
+     * @param days The number of days within which tasks should be due.
+     */
+    public ReminderCommand(int days) {
+        this.days = days;
+    }
+
+    @Override
+    public String execute(TaskList tasks, Ui ui, Storage storage) {
+        TaskList upcomingTasks = new TaskList();  // Create an empty TaskList for upcoming tasks
+
+        for (Task task : tasks.getAll()) {
+            if (task.isDueWithinDays(days)) {  // Check if the task is due within the specified number of days
+                upcomingTasks.add(task);
+            }
+        }
+
+        return ui.showUpcomingWeekTasks(upcomingTasks,this.days);
+    }
+}

--- a/src/main/java/Main/Parser.java
+++ b/src/main/java/Main/Parser.java
@@ -8,6 +8,7 @@ import Commands.DeleteCommand;
 import Commands.FindCommand;
 import Commands.ListCommand;
 import Commands.MarkCommand;
+import Commands.ReminderCommand;
 import Commands.UnmarkCommand;
 import Exception.DiegoException;
 import Exception.NoDescriptionException;
@@ -54,7 +55,19 @@ public class Parser {
             return new DeleteCommand(parseIndex(input));
         } else if (input.startsWith("find")) {
             return new FindCommand(input.substring(5).trim());
-        } else {
+        } else if (input.startsWith("remind")) {
+            String[] parts = input.split(" ");
+            //Default to 7 days if no number is provided
+            int days = 7;
+            if (parts.length > 1) {
+                try {
+                    days = Integer.parseInt(parts[1]);
+                } catch (NumberFormatException e) {
+                    throw new DiegoException("Invalid number of days for remind command.");
+                }
+            }
+            return new ReminderCommand(days);
+        }else {
             throw new UnknownCommandException();
         }
     }

--- a/src/main/java/Main/Ui.java
+++ b/src/main/java/Main/Ui.java
@@ -107,4 +107,24 @@ public class Ui {
         }
         return sb.toString().trim();
     }
+
+    /**
+     * Shows tasks that are due within the next week.
+     *
+     * @param tasks The task list that contains tasks due soon.
+     * @return A string listing the tasks due within the week.
+     */
+    public String showUpcomingWeekTasks(TaskList tasks, int days) {
+        if (tasks.size() == 0) {
+            return "No tasks are due within the next " + days + " days.";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Here are the tasks due within the next 7 days:\n");
+        for (int i = 0; i < tasks.size(); i++) {
+            sb.append(i + 1).append(". ").append(tasks.get(i)).append("\n");
+        }
+        return sb.toString();
+    }
 }
+

--- a/src/main/java/Tasks/Deadline.java
+++ b/src/main/java/Tasks/Deadline.java
@@ -2,6 +2,7 @@ package Tasks;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
@@ -105,4 +106,26 @@ public class Deadline extends Task {
                     + " | " + deadlineDate.format(DATE_FORMATS_WITHOUT_TIME.get(0));
         }
     }
+
+    /**
+     * Checks if the task is due within the next specified number of days.
+     * This is a default implementation that does nothing for tasks without deadlines/events.
+     *
+     * @param days The number of days to check for upcoming deadlines.
+     * @return false by default for tasks with no due date.
+     */
+    @Override
+    public boolean isDueWithinDays(int days) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (hasTime) {
+            long difference = now.until(deadlineDateTime, ChronoUnit.DAYS);
+            return difference >= 0 && difference <= days;
+        } else {
+            LocalDate today = now.toLocalDate();
+            long difference = today.until(deadlineDate, ChronoUnit.DAYS);
+            return difference >= 0 && difference <= days;
+        }
+    }
+
 }

--- a/src/main/java/Tasks/Event.java
+++ b/src/main/java/Tasks/Event.java
@@ -39,4 +39,13 @@ public class Event extends Task {
     public String toFileFormat() {
         return "E | " + (isDone ? "1" : "0") + " | " + description + " | " + start + " | " + end;
     }
+
+    /**
+     * Checks if the task is due within the next specified number of days.
+     * This is a default implementation that does nothing for tasks without deadlines/events.
+     *
+     * @param days The number of days to check for upcoming deadlines.
+     * @return false by default for tasks with no due date.
+     */
+
 }

--- a/src/main/java/Tasks/Task.java
+++ b/src/main/java/Tasks/Task.java
@@ -1,5 +1,8 @@
 package Tasks;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 /**
  * Represents an abstract task with a description and completion status.
  */
@@ -49,6 +52,17 @@ public abstract class Task {
      */
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * Checks if the task is due within the next specified number of days.
+     * This is a default implementation that does nothing for tasks without deadlines/events.
+     *
+     * @param days The number of days to check for upcoming deadlines.
+     * @return false by default for tasks with no due date.
+     */
+    public boolean isDueWithinDays(int days) {
+        return false;
     }
 
     /**


### PR DESCRIPTION
Added support for the 'remind' command, allowing users to receive reminders for tasks that are due within a given number of days. The default behavior reminds users of tasks due within 7 days if no specific number is provided.

- Introduced a new ReminderCommand class that accepts a dynamic number of days.
- Updated Task and Deadline classes to correctly handle date comparisons for upcoming tasks.
- Modified the Parser to handle 'remind [days]' commands, defaulting to 7 days if not specified.
- Updated the Ui class to display tasks due within the specified timeframe.